### PR TITLE
disable cleanExpiredFiles while running expired snapshots operation

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -2101,6 +2101,7 @@ public class IcebergMetadata
                     .retainLast(expireSnapshotsHandle.retainLast())
                     .cleanExpiredMetadata(expireSnapshotsHandle.cleanExpiredMetadata())
                     .planWith(icebergScanExecutor)
+                    .cleanExpiredFiles(false)
                     .commit();
         }
         catch (NotFoundException e) {


### PR DESCRIPTION
cleanExpiredFiles can cleanup unreferenced manifest lists or manifest files or metadata files. because we had a 400 day retention policy on the LTS bucket, the cleanup operation doesn't find the files and fails. this blocks resources on trino coordinator which then blocks user queries. to avoid this we want to disable cleanExpiredFiles option by default till the time trino gives an option to disable it via sql queries.